### PR TITLE
fix #8: add `ignoreEmpty` and `ignoreUndefined` in validate method options

### DIFF
--- a/lib/validr.js
+++ b/lib/validr.js
@@ -24,24 +24,34 @@ function generateValidatorClass(theValidator, superClass) {
   Object.keys(theValidator).forEach(function (method) {
 
     // Verify valid validator method.
-    var notValdator = (method.slice(0, 2) !== 'is'
+    var notValidator = (method.slice(0, 2) !== 'is'
       && method !== 'equals'
       && method !== 'contains'
       && method !== 'matches');
 
-    if (notValdator) return;
+    if (notValidator) return;
 
     // Setup validators.
     Class.prototype[method] = function () {
-      var args, bool, msg;
+      var args, isValid, msg;
 
       args = Array.prototype.slice.call(arguments);
+
+      if (this._options.ignoreEmpty && _.isEmpty(args[0]) ) {
+        return this;
+      }
+
+      if (this._options.ignoreUndefined && _.isUndefind(args[0]) ) {
+        return this;
+      }
+
+
       args.unshift(this._value);
 
-      bool = theValidator[method].apply(theValidator[method], args);
+      isValid = theValidator[method].apply(theValidator[method], args);
 
       // Exit if valid.
-      if (bool) return this;
+      if (isValid) return this;
 
       if (typeof this._msg === 'string')
         msg = this._msg;
@@ -118,9 +128,10 @@ Validr.prototype._sanitizers;
  * 
  * @param {string|array} param
  * @param {string|object} msg
+ * @param {object} opitons supports `ignoreEmpty` and `ignoreUndefined` to not validate
  * @return {object} this._validator
  */
-Validr.prototype.validate = function (param, msg){
+Validr.prototype.validate = function (param, msg, options){
   var value,
     that = this;
 
@@ -142,6 +153,8 @@ Validr.prototype.validate = function (param, msg){
   that._param = that._validator._param = param.join('.');
   that._value = that._validator._value = value;
   that._msg = that._validator._msg = msg;
+
+  that._validator._options = options || {};
 
   return that._validator;
 };

--- a/test/validr.js
+++ b/test/validr.js
@@ -133,6 +133,40 @@ describe('validr', function () {
         msg: 'Email must be valid.'
       });
     });
+
+    it('should return null if ignoreEmpty', function (){
+      var body = _.cloneDeep(user);
+      body.email = '';
+      var validr = new Validr(body);
+
+      validr.validate('email', {
+        isLength: 'Email is required.',
+        isEmail: 'Email must be valid.'
+      }, {
+        ignoreEmpty: true
+      }).isLength(1).isEmail();
+
+      var errors = validr.validationErrors(true);
+      (!errors).should.be.ok;
+    });
+
+    it('should return null if ignoreEmpty', function (){
+      var body = _.cloneDeep(user);
+      delete body.email;
+      var validr = new Validr(body);
+
+      validr.validate('email', {
+        isLength: 'Email is required.',
+        isEmail: 'Email must be valid.'
+      }, {
+        ignoreEmpty: true
+      }).isLength(1).isEmail();
+
+      var errors = validr.validationErrors(true);
+      (!errors).should.be.ok;
+    });
+
+
   });
 
   describe('#extendValidator ', function() {


### PR DESCRIPTION
Add `options` parameter to `validate` method so that we can ignore empty & undefined fields optionally.