### PR TITLE
fix #13: no need to require validator methods starting with `is`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,7 @@ mappedErrors:
 
 ### Extending with custom validators
 
-Add custom validator functions to an object which is the second parameter when instantiating Validr. Ensure validator's name begins with an _is_.
-
+Add custom validator functions to an object which is the second parameter when instantiating Validr.
 ```javascript
 var validr = new Validr(body, {
   isNotExampleEmail: function(str) {

--- a/lib/validr.js
+++ b/lib/validr.js
@@ -23,14 +23,6 @@ function generateValidatorClass(theValidator, superClass) {
   // Setup validators.
   Object.keys(theValidator).forEach(function (method) {
 
-    // Verify valid validator method.
-    var notValidator = (method.slice(0, 2) !== 'is'
-      && method !== 'equals'
-      && method !== 'contains'
-      && method !== 'matches');
-
-    if (notValidator) return;
-
     // Setup validators.
     Class.prototype[method] = function () {
       var args, isValid, msg;


### PR DESCRIPTION
It would save a lot of time for debugging if no start-with-is limitation. Fix #13 
